### PR TITLE
fixed yaml encoding

### DIFF
--- a/data/services/clothing.yml
+++ b/data/services/clothing.yml
@@ -1,80 +1,79 @@
-
-
 -
-
-   title: Joseph’s Coat Furniture Ministry 
-   description: | Household goods and furniture items, including cookware, small 
-and large appliances, and more. There is a truck available for delivery on Saturday mornings from 8 am 
-until noon, and other times by appointment. You may walk in or call to request specific items.
-   phone: 614-863-1371 
-   physical_address: | 240-C Outerbelt St, 43213
-   hours: Wednesdays and Saturdays from 9 am to noon; Tuesdays 6 – 8 pm
+   title: Joseph's Coat Furniture Ministry
+   description:
+     Household goods and furniture items, including cookware, small and large
+     appliances, and more. There is a truck available for delivery on Saturday
+     mornings from 8 am until noon, and other times by appointment. You may walk
+     in or call to request specific items.
+   phone: 614-863-1371
+   physical_address: 240-C Outerbelt St, 43213
+   hours: Wednesdays and Saturdays from 9 am to noon; Tuesdays 6 -  8 pm
    website: http://josephscoatofohio.org/
-
 -
-
-   title:The Furniture Bank of Central Ohio 
-   description: | By referral only. If you are linked with a partner agency or if 
-you have a Children’s Services case worker, they may be able to schedule your appointment for you. 
-Otherwise, please call HandsOn at 211 or 614-221-2255. The Furniture Bank offers many new and used 
-furniture items, appliances, and other housewares. They have a truck available for delivery, and will 
-deliver curbside. It is important not to be late to or miss your appointment, as you may have to 
-reschedule for another day.
-   physical_address: | 118 South Yale Avenue, 43222  
+   title: The Furniture Bank of Central Ohio
+   description:
+     By referral only. If you are linked with a partner agency or if you have a
+     Children's Services case worker, they may be able to schedule your
+     appointment for you. Otherwise, please call HandsOn at 211 or 614-221-2255.
+     The Furniture Bank offers many new and used furniture items, appliances,
+     and other housewares. They have a truck available for delivery, and will
+     deliver curbside. It is important not to be late to or miss your
+     appointment, as you may have to reschedule for another day.
+   physical_address: 118 South Yale Avenue, 43222
    website: http://www.furniturebankcoh.org/
-
 -
-
-   title: Westside Free Store Ministries 
-   description: | Offers free clothing for all ages (including career clothing household 
-items, linens, books, toys, small appliances, and personal hygiene items). Spanish interpreters available 
-during store hours.
-   phone: 614-351-5480 
-   physical_address: | Westgate United Methodist Church, 3030 Sullivant Ave, 43204 Hours: 
+   title: Westside Free Store Ministries
+   description:
+     Offers free clothing for all ages (including career clothing household
+     items, linens, books, toys, small appliances, and personal hygiene items).
+     Spanish interpreters available during store hours.
+   phone: 614-351-5480
+   physical_address: Westgate United Methodist Church, 3030 Sullivant Ave, 43204
    hours: Monday 10 am - 12:30 pm; Thursday 3 - 5:30 pm; Saturday 12 - 12:30 pm
    website: http://www.westsidefreestore.org/
 -
 
-   title: Baptists for Life of Central Ohio’s Maternity Resource Center 
-   description: | Provides maternity clothing and 
-children’s clothing up to size 6X, disposable diapers, and some baby furniture and equipment.
+   title: Baptists for Life of Central Ohio's Maternity Resource Center
+   description:
+     Provides maternity clothing and children's clothing up to size 6X,
+     disposable diapers, and some baby furniture and equipment.
    phone: 614-272-7038
-   physical_address: | Immanuel Baptist Church, 3417 Palmetto St, 43204
-   hours: Wednesday 6:30 – 8 pm; Saturday 10 am - 12:30 pm
+   physical_address: Immanuel Baptist Church, 3417 Palmetto St, 43204
+   hours: Wednesday 6:30 - 8 pm; Saturday 10 am - 12:30 pm
    website: http://www.bflco.org/maternity-resource-center/
 -
 
    title: Community Kitchen Clothing Room
-   description: | Provides free used clothing and small household items. Limit 6 
-visits per year or every other month. 
+   description:
+     Provides free used clothing and small household items. Limit 6 visits per
+     year or every other month.
    phone: 614-252-6428 ext. 238
-   physical_address: | 640 South Ohio Ave, 43205
-   hours: Tuesday – Friday 10am-2pm
+   physical_address: 640 South Ohio Ave, 43205
+   hours: Tuesday - Friday 10am-2pm
    website: http://www.communitykitchencolumbus.org/resources.html
 -
-
-   title: United Methodist Free Store 
-   description: | Free clothing and shoes for infants, children, and adults. Household 
-items and small appliances available.
+   title: United Methodist Free Store
+   description:
+     Free clothing and shoes for infants, children, and adults.  Household items
+     and small appliances available.
    phone:  614-443-1713
-   physical_address: | 946 Parsons Ave, 43206
-   hours: Tuesday, Thursday, and Saturday 10 am – 1 pm; Wednesday 1 – 4 pm; Friday 3 –6 pm    
+   physical_address: 946 Parsons Ave, 43206
+   hours: Tuesday, Thursday, and Saturday 10 am - 1 pm; Wednesday 1 - 4 pm; Friday 3 - 6 pm
    website: http://www.4allpeople.org/freestore.html
 -
-
-   title: Bishop Griffin Center Free Store 
-   description: |Offers clothing and household items.
+   title: Bishop Griffin Center Free Store
+   description: Offers clothing and household items.
    phone: 614-338-8220
-   physical address: | 2875 E Livingston Ave, 43209
-   hours: Wednesday 9 am – 12 pm; Friday 2:30-5:30 pm; First Wednesday of the month 5-7 pm     
+   physical address: 2875 E Livingston Ave, 43209
+   hours: Wednesday 9 am - 12 pm; Friday 2:30-5:30 pm; First Wednesday of the month 5-7 pm
    website: http://www.bishopgriffincenter.com/
 -
-
    title: Dublin Furniture Banc
-   description: | Similar to the Furniture Bank of Central Ohio, this resource offers furniture 
-by referral only. To find a referring agency, call HandsOn Central Ohio at 211. If an agency cannot 
-cover the cost of your appointment, the appointment will be $60 and the curbside delivery $40-50. 
-   phone: 614-333-6207 
-   physical_address: | 6253 Old Avery Rd, Dublin, OH, 43016      
+   description:
+     Similar to the Furniture Bank of Central Ohio, this resource offers
+     furniture by referral only. To find a referring agency, call HandsOn
+     Central Ohio at 211. If an agency cannot cover the cost of your
+     appointment, the appointment will be $60 and the curbside delivery $40-50.
+   phone: 614-333-6207
+   physical_address: 6253 Old Avery Rd, Dublin, OH, 43016
    website: http://www.dublinfurniturebanc.org/
-


### PR DESCRIPTION
There were some odd characters that were throwing off the parsing, I think it may have been UTF-16 encoded or something. Either way, not a big deal. Mainly just changed the mystery characters to `-` and `'`, and cleaned up some line lengths
